### PR TITLE
Added a Dockerfile and documentation for a Docker cli run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+# syntax=docker/dockerfile:1
+FROM node:16-alpine
+RUN mkdir /app
+COPY . /app
+WORKDIR /app
+RUN npm i -g roboflow-cli
+ENTRYPOINT ["roboflow"]

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ If you don't want to install node, npm and other roboflow cli dependencies, but 
 Assuming you have docker installed on your machine, first build the image
 
 ```
-docker build -t roboflowcli .
+docker build -t roboflowcli:latest .
 ```
 
 Then, run the roboflow cli docker image interactively like so
@@ -70,11 +70,11 @@ Then, run the roboflow cli docker image interactively like so
 ```
 # Authorize 
 
-docker run -it -v ~/.config/roboflow:/root/.config/roboflow roboflowcli:2 roboflow auth
+docker run -it -v ~/.config/roboflow:/root/.config/roboflow roboflowcli:latest roboflow auth
 
 # Use the CLI as usual inside a docker container.
 
-docker run -it -v ~/.config/roboflow:/root/.config/roboflow roboflowcli:2 roboflow project list
+docker run -it -v ~/.config/roboflow:/root/.config/roboflow roboflowcli:latest roboflow project list
 ```
 
 Here we have mounted the roboflow credentials into the docker container. The first docker command authorizes the user and stores credentials 

--- a/README.md
+++ b/README.md
@@ -52,3 +52,32 @@ or
 ```
 roboflow detect -h
 ```
+
+### Run the CLI in a docker container (alpha support)
+
+If you don't want to install node, npm and other roboflow cli dependencies, but still use the roboflow cli you can run it in a docker container.
+
+Assuming you have docker installed on your machine, first build the image
+
+```
+docker build -t roboflowcli .
+```
+
+Then, run the roboflow cli docker image interactively like so
+
+
+
+```
+# Authorize 
+
+docker run -it -v ~/.config/roboflow:/root/.config/roboflow roboflowcli:2 roboflow auth
+
+# Use the CLI as usual inside a docker container.
+
+docker run -it -v ~/.config/roboflow:/root/.config/roboflow roboflowcli:2 roboflow project list
+```
+
+Here we have mounted the roboflow credentials into the docker container. The first docker command authorizes the user and stores credentials 
+in the user's `$HOME/.config/roboflow` directory. These credentials are then mounted onto the docker container in subsequent runs, as shown above.
+
+You will similarly have to mount any data directories in case you are uploading images or annotations, for example.


### PR DESCRIPTION
# Description

Dockerfile and docs for installing and running the cli inside a docker container.

Helps folks who dont want/know/or are unable to work with node/npm.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Works on my mac.

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
