### PR TITLE
fallback to authed workspace api key for getting public projects

### DIFF
--- a/cli/commands/inference.js
+++ b/cli/commands/inference.js
@@ -3,11 +3,11 @@ const axios = require("axios");
 const fs = require("fs");
 
 const api = require("../../api.js");
-const { getApiKeyWorWorkspace } = require("../core.js");
+const { getApiKeyForWorkspace } = require("../core.js");
 
 async function infer(args, options) {
     const workspaceUrl = options.workspace;
-    const apiKey = getApiKeyWorWorkspace(workspaceUrl);
+    const apiKey = getApiKeyForWorkspace(workspaceUrl);
 
     // console.log("infer", args, options);
 
@@ -49,7 +49,7 @@ async function infer(args, options) {
 
 async function detectObject(args, options) {
     const workspaceUrl = options.workspace;
-    const apiKey = getApiKeyWorWorkspace(workspaceUrl);
+    const apiKey = getApiKeyForWorkspace(workspaceUrl);
 
     const modelUrl = options.model;
     const file = args;
@@ -63,7 +63,7 @@ async function detectObject(args, options) {
 
 async function classify(args, options) {
     const workspaceUrl = options.workspace;
-    const apiKey = getApiKeyWorWorkspace(workspaceUrl);
+    const apiKey = getApiKeyForWorkspace(workspaceUrl);
 
     const modelUrl = options.model;
     const file = args;
@@ -74,7 +74,7 @@ async function classify(args, options) {
 
 async function instanceSegmentation(args, options) {
     const workspaceUrl = options.workspace;
-    const apiKey = getApiKeyWorWorkspace(workspaceUrl);
+    const apiKey = getApiKeyForWorkspace(workspaceUrl);
 
     const modelUrl = options.model;
     const file = args;
@@ -85,7 +85,7 @@ async function instanceSegmentation(args, options) {
 
 async function semanticSegmentation(args, options) {
     const workspaceUrl = options.workspace;
-    const apiKey = getApiKeyWorWorkspace(workspaceUrl);
+    const apiKey = getApiKeyForWorkspace(workspaceUrl);
 
     const modelUrl = options.model;
     const file = args;

--- a/cli/commands/project.js
+++ b/cli/commands/project.js
@@ -3,7 +3,7 @@ const { link } = require("../utils");
 const config = require("../../config");
 
 const { getWorkspace, getProject } = require("../../api.js");
-const { getApiKeyWorWorkspace } = require("../core.js");
+const { hasApiKeyForWorkspace, getApiKeyForWorkspace } = require("../core.js");
 
 function printProject(p) {
     const app_url = config.get("RF_APP_URL");
@@ -22,7 +22,7 @@ function printProject(p) {
 
 async function listProjects(options) {
     const workspaceUrl = options.workspace;
-    const apiKey = getApiKeyWorWorkspace(workspaceUrl);
+    const apiKey = getApiKeyForWorkspace(workspaceUrl);
 
     const workspaceData = await getWorkspace(workspaceUrl, apiKey);
 
@@ -45,9 +45,14 @@ async function projectDetails(projectId, options) {
         [workspaceUrl, projectUrl] = projectId.split("/");
     }
 
-    console.log(workspaceUrl, projectUrl);
-
-    const apiKey = getApiKeyWorWorkspace(workspaceUrl);
+    let apiKey;
+    if (hasApiKeyForWorkspace(workspaceUrl)) {
+        apiKey = getApiKeyForWorkspace(workspaceUrl);
+    } else {
+        //fallback to default workspace or the one sepcified via --workspace if the one in
+        // the project id is not one we have an api key for (e.g. for public projects on universe)
+        apiKey = getApiKeyForWorkspace(options.workspace);
+    }
 
     const result = await getProject(workspaceUrl, projectUrl, apiKey);
     console.log(result);

--- a/cli/commands/upload.js
+++ b/cli/commands/upload.js
@@ -4,7 +4,7 @@ const pLimit = require("p-limit");
 
 const annotation = require("@roboflow/annotation");
 
-const { selectProjectFromWorkspace, getApiKeyWorWorkspace } = require("../core.js");
+const { selectProjectFromWorkspace, getApiKeyForWorkspace } = require("../core.js");
 
 const { parseFolder } = require("../datasetParser");
 
@@ -44,7 +44,7 @@ async function uploadSimple(f, projectUrl, apiKey, extraOption) {
 
 async function uploadImage(args, options) {
     const workspaceUrl = options.workspace;
-    const apiKey = getApiKeyWorWorkspace(workspaceUrl);
+    const apiKey = getApiKeyForWorkspace(workspaceUrl);
     let projectUrl = options.project;
 
     if (!projectUrl) {
@@ -129,7 +129,7 @@ async function uploadParsedDatasetImage(
 
 async function importDataset(datasetFolder, options) {
     const workspaceUrl = options.workspace;
-    const apiKey = getApiKeyWorWorkspace(workspaceUrl);
+    const apiKey = getApiKeyForWorkspace(workspaceUrl);
     let projectUrl = options.project;
 
     if (!projectUrl) {

--- a/cli/commands/workspace.js
+++ b/cli/commands/workspace.js
@@ -3,7 +3,7 @@ const chalk = require("chalk");
 const { link } = require("../utils");
 
 const { getWorkspace } = require("../../api.js");
-const { getApiKeyWorWorkspace, selectWorkspace } = require("../core.js");
+const { getApiKeyForWorkspace, selectWorkspace } = require("../core.js");
 
 require("util").inspect.defaultOptions.depth = null;
 
@@ -54,7 +54,7 @@ async function listWorkspaces() {
 
 async function workspaceDetails(options) {
     const workspaceUrl = options.workspace;
-    const apiKey = getApiKeyWorWorkspace(workspaceUrl);
+    const apiKey = getApiKeyForWorkspace(workspaceUrl);
 
     const workspaceData = await getWorkspace(workspaceUrl, apiKey);
     console.log(workspaceData);

--- a/cli/core.js
+++ b/cli/core.js
@@ -4,7 +4,25 @@ const config = require("../config.js");
 
 const { getWorkspace } = require("../api.js");
 
-function getApiKeyWorWorkspace(workspaceId) {
+function hasApiKeyForWorkspace(workspaceId) {
+    const workspaces = config.get("workspaces");
+
+    if (!workspaces) {
+        return false;
+    }
+
+    const workspaceConf = Object.values(workspaces).find(
+        (ws) => ws.url == workspaceId || ws.id == workspaceId
+    );
+
+    if (workspaceConf && workspaceConf.apiKey) {
+        return true;
+    }
+
+    return false;
+}
+
+function getApiKeyForWorkspace(workspaceId) {
     const workspaces = config.get("workspaces");
 
     if (!workspaces) {
@@ -41,7 +59,7 @@ async function selectWorkspace() {
 
     if (Object.keys(workspaces).length == 1) {
         console.log(
-            "nothign to select from, only 1 default workspace authorized:",
+            "Nothing to select from, only 1 default workspace authorized:",
             chalk.green(Object.values(workspaces)[0].url)
         );
         return Object.values(workspaces)[0].url;
@@ -69,7 +87,7 @@ async function selectWorkspace() {
 }
 
 async function selectProjectFromWorkspace(workspaceUrl) {
-    const apiKey = getApiKeyWorWorkspace(workspaceUrl);
+    const apiKey = getApiKeyForWorkspace(workspaceUrl);
     const workspaceData = await getWorkspace(workspaceUrl, apiKey);
     const projects = workspaceData.workspace?.projects;
 
@@ -109,7 +127,8 @@ async function selectProjectFromWorkspace(workspaceUrl) {
 }
 
 module.exports = {
-    getApiKeyWorWorkspace,
+    hasApiKeyForWorkspace,
+    getApiKeyForWorkspace,
     selectWorkspace,
     selectProjectFromWorkspace
 };


### PR DESCRIPTION
When specifying a project id for e.g. commands like `roboflow project get augmented-startups/playing-cards-ow27d`, we use the workspace in the porject id to look up the api key.  However, for public projects on universe, we need to use the api key of one of the authed workspaces instead.  This was kind of working when e.g. just specifying the project url without the workspace url (e.g. `roboflow project get playing-cards-ow27d`).

This PR changes it so we check whether we have a API key for the project specific workspace, and if not we fallback to getting the api for an authed workspace (wither default workspace or the one specified via `--workspace` option

Also fixed some typos (one mentioned [here](https://github.com/roboflow-ai/roboflow-cli/issues/2) and renaming `getApiKeyWorWorkspace` to getApiKeyForWorkspace