### PR TITLE
Fixed README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ Then, run the roboflow cli docker image interactively like so
 ```
 # Authorize 
 
-docker run -it -v ~/.config/roboflow:/root/.config/roboflow roboflowcli:latest auth
+docker run -it --rm -v ~/.config/roboflow:/root/.config/roboflow roboflowcli:latest auth
 
 # Use the CLI as usual inside a docker container.
 
-docker run -it -v ~/.config/roboflow:/root/.config/roboflow roboflowcli:latest project list
+docker run -it --rm -v ~/.config/roboflow:/root/.config/roboflow roboflowcli:latest project list
 ```
 
 Here we have mounted the roboflow credentials into the docker container. The first docker command authorizes the user and stores credentials 

--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ Then, run the roboflow cli docker image interactively like so
 ```
 # Authorize 
 
-docker run -it -v ~/.config/roboflow:/root/.config/roboflow roboflowcli:latest roboflow auth
+docker run -it -v ~/.config/roboflow:/root/.config/roboflow roboflowcli:latest auth
 
 # Use the CLI as usual inside a docker container.
 
-docker run -it -v ~/.config/roboflow:/root/.config/roboflow roboflowcli:latest roboflow project list
+docker run -it -v ~/.config/roboflow:/root/.config/roboflow roboflowcli:latest project list
 ```
 
 Here we have mounted the roboflow credentials into the docker container. The first docker command authorizes the user and stores credentials 


### PR DESCRIPTION


# Description

Added rm flag to remove stopped docker container, 
also removed roboflow executable as its already inclded in the entrypoint so shouldn't be added to the docker run

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

locally 
