### PR TITLE
added glob support for windows

### DIFF
--- a/cli/commands/upload.js
+++ b/cli/commands/upload.js
@@ -8,6 +8,8 @@ const { selectProjectFromWorkspace, getApiKeyForWorkspace } = require("../core.j
 
 const { parseFolder } = require("../datasetParser");
 
+const glob = require('glob');
+
 const api = require("../../api.js");
 
 async function uploadWithAnnotation(f, annotationFilename, projectUrl, apiKey, extraOptions) {
@@ -77,8 +79,11 @@ async function uploadImage(args, options) {
 
     const limit = pLimit(concurrency);
 
+    // glob files if wildcard in args
+    var globbed_files = args[0].includes("*") ? await glob.sync(args[0]) : args
+    
     if (options.annotation) {
-        for (let f of args) {
+        for (let f of globbed_files) {
             const p = limit(() =>
                 uploadWithAnnotation(f, options.annotation, projectUrl, apiKey, extraOptions)
             );
@@ -86,7 +91,7 @@ async function uploadImage(args, options) {
             uploadPromises.push(p);
         }
     } else {
-        for (let f of args) {
+        for (let f of globbed_files) {
             const p = limit(() => uploadSimple(f, projectUrl, apiKey, extraOptions));
             uploadPromises.push(p);
         }


### PR DESCRIPTION
# Description

For some odd reason, Windows does not provide `args` an array of filenames when using the `*.ext` format with files. This fix enables users to perform bulk uploads via Windows CLI.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Uploaded a customer dataset from both Windows and Mac.

