### PR TITLE
Login Alias

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "cSpell.words": [
+        "Roboflow",
+        "roboflowcli"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ npm i -g roboflow-cli
 
 ### Authorize the CLI
 
-To authotize your CLI, run the following command.
+To authorize your CLI, run the following command.
 
 ```
-roboflow auth
+roboflow login
 ```
 
 This will open a browser window and have you log into roboflow where you can select any workspaces you want the CLI to store auth credentials for (The CLi will download the api keys for the workspaces and store them in a config fle in the `~/.config/roboflow` directory on your system).
@@ -41,7 +41,7 @@ For more info on how to use the CLI see the help an usage instructions by runnin
 roboflow -h
 ```
 
-You can also get specific help for each of the available sucommands, like e.g.:
+You can also get specific help for each of the available subcommands, like e.g.:
 
 ```
 roboflow upload -h

--- a/cli/commands/auth.js
+++ b/cli/commands/auth.js
@@ -10,11 +10,11 @@ module.exports = async function auth() {
     const authUrl = `${config.get("RF_APP_URL")}/auth-cli`;
 
     try {
-        console.log("opening webrowser for you to log in and retrieve auth token...");
+        console.log("opening web browser for you to log in and retrieve auth token...");
         open(authUrl);
     } catch (e) {
         console.log();
-        console.log(chalk.red("failed to open a webrowser."));
+        console.log(chalk.red("failed to open a web browser."));
     }
 
     console.log(
@@ -33,7 +33,7 @@ ${chalk.green(authUrl)}
     const token_input = await enquirer.prompt({
         type: "text",
         name: "cli_auth_token",
-        message: "Please paste the cli auth token displayed in the webrowser"
+        message: "Please paste the cli auth token displayed in the web browser"
     });
 
     // fetch workspace info and auth data using the auth token

--- a/cli/commands/download.js
+++ b/cli/commands/download.js
@@ -278,7 +278,7 @@ async function downloadDataset(datasetUrl, options) {
     if (hasApiKeyForWorkspace(workspaceUrl)) {
         apiKey = getApiKeyForWorkspace(workspaceUrl);
     } else {
-        //fallback to default workspace or the one sepcified via --workspace if the one in
+        // fallback to default workspace or the one specified via --workspace if the one in
         // the project id is not one we have an api key for (e.g. for public projects on universe)
         apiKey = getApiKeyForWorkspace(options.workspace);
     }
@@ -316,7 +316,7 @@ async function downloadDataset(datasetUrl, options) {
         format = await pickFormatInteractively(projectData);
     }
 
-    // console.log("DOWNALOD DATASET:", workspaceUrl, projectUrl, version, format, apiKey);
+    // console.log("DOWNLOAD DATASET:", workspaceUrl, projectUrl, version, format, apiKey);
 
     const downloadLink = await getDownloadLink(workspaceUrl, projectUrl, version, format, apiKey);
 

--- a/cli/commands/project.js
+++ b/cli/commands/project.js
@@ -49,7 +49,7 @@ async function projectDetails(projectId, options) {
     if (hasApiKeyForWorkspace(workspaceUrl)) {
         apiKey = getApiKeyForWorkspace(workspaceUrl);
     } else {
-        //fallback to default workspace or the one sepcified via --workspace if the one in
+        // fallback to default workspace or the one specified via --workspace if the one in
         // the project id is not one we have an api key for (e.g. for public projects on universe)
         apiKey = getApiKeyForWorkspace(options.workspace);
     }

--- a/cli/commands/workspace.js
+++ b/cli/commands/workspace.js
@@ -27,7 +27,7 @@ async function listWorkspaces() {
 
     if (!workspaces) {
         console.log(
-            "No workspaces found. You may need to run " + chalk.bold("roboflow auth") + " first"
+            "No workspaces found. You may need to run " + chalk.bold("roboflow login") + " first"
         );
         return;
     }

--- a/cli/core.js
+++ b/cli/core.js
@@ -33,7 +33,7 @@ function getApiKeyForWorkspace(workspaceId) {
 
     if (!workspaces) {
         console.log(
-            "No workspaces found. You may need to run " + chalk.bold("roboflow auth") + " first"
+            "No workspaces found. You may need to run " + chalk.bold("roboflow login") + " first"
         );
         process.exit(1);
     }
@@ -45,7 +45,7 @@ function getApiKeyForWorkspace(workspaceId) {
     if (!workspaceConf.apiKey) {
         console.log(
             "Could not find api key for the specified workspace. You may need to run " +
-                chalk.bold("roboflow auth") +
+                chalk.bold("roboflow login") +
                 " first"
         );
         process.exit(1);
@@ -59,7 +59,7 @@ async function selectWorkspace() {
 
     if (!workspaces) {
         console.log(
-            "No workspaces found. You may need to run " + chalk.bold("roboflow auth") + "first"
+            "No workspaces found. You may need to run " + chalk.bold("roboflow login") + "first"
         );
     }
 
@@ -208,8 +208,8 @@ async function selectInstanceSegFormat() {
             { name: "'darknet' (Converts to Object-Detection: YOLO Darknet)", value: "darknet" },
             { name: "'voc' (Converts to Object-Detection: Pascal VOC)", value: "voc" },
             {
-                name: "'tfrecrod' (Converts to Object-Detection: Tensorflow TFRecord)",
-                value: "tfrecrod"
+                name: "'tfrecord' (Converts to Object-Detection: Tensorflow TFRecord)",
+                value: "tfrecord"
             },
             { name: "'createml' (Converts to Object-Detection: CreateML)", value: "createml" }
         ],

--- a/cli/index.js
+++ b/cli/index.js
@@ -36,6 +36,7 @@ async function main() {
 
     program
         .command("auth")
+        .alias("login")
         .description("log in to roboflow to store auth credentials for your workspaces")
         .action(auth);
 


### PR DESCRIPTION
# Description

Aliases `roboflow auth` to `roboflow login` which better matches other CLI's and the vocabulary we're going to use in the pip package.

Also fixes several spelling mistakes & updates some copy.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Not yet; @hansent will you show me how to spin this up locally to test & deploy?

## Any specific deployment considerations

Need to push to npm.

## Docs

-   [ ] Should update `roboflow auth` to `roboflow login` in docs for unification (even though `roboflow auth` will still work for backwards-compatibility).
