### PR TITLE
Fix import command on Windows

### DIFF
--- a/cli/commands/upload.js
+++ b/cli/commands/upload.js
@@ -176,7 +176,7 @@ async function importDataset(datasetFolder, options) {
         uploadPromises.push(p);
     }
 
-    // await Promise.all(uploadPromises);
+    await Promise.all(uploadPromises);
 }
 
 module.exports = {

--- a/cli/datasetParser.js
+++ b/cli/datasetParser.js
@@ -10,7 +10,7 @@ function listFilesInFolder(folder) {
     const dirName = path.relative("", path.resolve(folder));
     const globPattern = path.join(dirName, "**/*");
 
-    return glob.sync(globPattern);
+    return glob.sync(globPattern.replace(/\\/g, '/'));
 }
 
 function isImageFile(f) {


### PR DESCRIPTION
Import command (e.g. `roboflow import C:\Users\Jake\Downloads\Aerial_Maritime.v24i.yolov8 -p test-zixpe` would not work on windows, and just failed silently.

Replace forward slashes in globPattern with backslashes, needs to be in POSIX format. See https://stackoverflow.com/questions/55512907/node-glob-sync-returns-empty-array

It seems to me like this only works for PASCAL VOC format. I tried uploading YOLOv8 PyTorch TXT annotations, which didn't work, and just resulted in annotations covering the entire image. PASCAL VOC seems to work.

# Description

Please include a summary of the change and which issue is fixed or implemented. Please also include relevant motivation and context (e.g. links, docs, tickets etc.).

Uncommented `await Promise.all(uploadPromises);` in `upload.js`

Replace forward slashes with backslashes to match format expected by `glob.sync`

## Type of change

-   [✔ ] Bug fix (non-breaking change which fixes an issue)
