### PR TITLE
Removed a comment blocking dataset import functionality

### DIFF
--- a/cli/commands/upload.js
+++ b/cli/commands/upload.js
@@ -176,7 +176,7 @@ async function importDataset(datasetFolder, options) {
         uploadPromises.push(p);
     }
 
-    // await Promise.all(uploadPromises);
+    await Promise.all(uploadPromises);
 }
 
 module.exports = {


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed or implemented. Please also include relevant motivation and context (e.g. links, docs, tickets etc.).

List any dependencies that are required for this change.

There was a comment blocking out the line where all the promises for uploading images would occur.

Resolving an issue raised by a forum user: https://discuss.roboflow.com/t/upload-dataset-from-gcp-vm-gcp-cloud-storage/2632

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

